### PR TITLE
Integrate LLM‑Viewer cost model

### DIFF
--- a/vidur/vidur/config/config.py
+++ b/vidur/vidur/config/config.py
@@ -728,6 +728,18 @@ class RandomForrestExecutionTimePredictorConfig(BaseExecutionTimePredictorConfig
 
 
 @dataclass
+class LLMViewerExecutionTimePredictorConfig(BaseExecutionTimePredictorConfig):
+    hardware: str = field(
+        default="A100",
+        metadata={"help": "Hardware name for LLM-Viewer."},
+    )
+
+    @staticmethod
+    def get_type():
+        return ExecutionTimePredictorType.LLM_VIEWER
+
+
+@dataclass
 class ClusterConfig:
     num_replicas: int = field(
         default=1,

--- a/vidur/vidur/execution_time_predictor/__init__.py
+++ b/vidur/vidur/execution_time_predictor/__init__.py
@@ -4,5 +4,12 @@ from vidur.execution_time_predictor.base_execution_time_predictor import (
 from vidur.execution_time_predictor.execution_time_predictor_registry import (
     ExecutionTimePredictorRegistry,
 )
+from vidur.execution_time_predictor.llm_viewer_execution_time_predictor import (
+    LLMViewerExecutionTimePredictor,
+)
 
-__all__ = [ExecutionTimePredictorRegistry, BaseExecutionTimePredictor]
+__all__ = [
+    ExecutionTimePredictorRegistry,
+    BaseExecutionTimePredictor,
+    LLMViewerExecutionTimePredictor,
+]

--- a/vidur/vidur/execution_time_predictor/execution_time_predictor_registry.py
+++ b/vidur/vidur/execution_time_predictor/execution_time_predictor_registry.py
@@ -4,6 +4,9 @@ from vidur.execution_time_predictor.linear_regression_execution_time_predictor i
 from vidur.execution_time_predictor.random_forrest_execution_time_predictor import (
     RandomForrestExecutionTimePredictor,
 )
+from vidur.execution_time_predictor.llm_viewer_execution_time_predictor import (
+    LLMViewerExecutionTimePredictor,
+)
 from vidur.types import ExecutionTimePredictorType
 from vidur.utils.base_registry import BaseRegistry
 
@@ -19,4 +22,7 @@ ExecutionTimePredictorRegistry.register(
 )
 ExecutionTimePredictorRegistry.register(
     ExecutionTimePredictorType.LINEAR_REGRESSION, LinearRegressionExecutionTimePredictor
+)
+ExecutionTimePredictorRegistry.register(
+    ExecutionTimePredictorType.LLM_VIEWER, LLMViewerExecutionTimePredictor
 )

--- a/vidur/vidur/execution_time_predictor/llm_viewer_execution_time_predictor.py
+++ b/vidur/vidur/execution_time_predictor/llm_viewer_execution_time_predictor.py
@@ -1,0 +1,117 @@
+from typing import List, Tuple
+
+from vidur.config import (
+    BaseReplicaSchedulerConfig,
+    MetricsConfig,
+    BaseExecutionTimePredictorConfig,
+    ReplicaConfig,
+)
+from vidur.entities import Batch
+from vidur.execution_time_predictor.base_execution_time_predictor import (
+    BaseExecutionTimePredictor,
+)
+
+import os
+import sys
+
+# Add LLM-Viewer to path for importing
+LLM_VIEWER_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "..", "LLM-Viewer")
+sys.path.append(os.path.abspath(LLM_VIEWER_DIR))
+from model_analyzer import ModelAnalyzer
+
+
+class LLMViewerExecutionTimePredictor(BaseExecutionTimePredictor):
+    """Execution time predictor using LLM-Viewer."""
+
+    def __init__(
+        self,
+        predictor_config: BaseExecutionTimePredictorConfig,
+        replica_config: ReplicaConfig,
+        replica_scheduler_config: BaseReplicaSchedulerConfig,
+        metrics_config: MetricsConfig,
+    ) -> None:
+        super().__init__(
+            predictor_config=predictor_config,
+            replica_config=replica_config,
+            replica_scheduler_config=replica_scheduler_config,
+            metrics_config=metrics_config,
+        )
+        model_id = self._model_config.get_name()
+        hardware = self._replica_config.device.upper()
+        self._analyzer = ModelAnalyzer(model_id, hardware)
+        self._cache = {}
+
+    def _predict_per_layer_time_ms(self, batch: Batch) -> float:
+        if batch.id not in self._cache:
+            token_counts: List[Tuple[int, int]] = [
+                (t, r.num_processed_tokens)
+                for r, t in zip(batch.requests, batch.num_tokens)
+            ]
+            result = self._analyzer.analyze(mode="hybrid", token_counts=token_counts)
+            total_time_s = result["total_results"]["hybrid"]["inference_time"]
+            total_time_ms = total_time_s * 1000
+            per_stage_ms = total_time_ms / self._replica_config.num_pipeline_stages
+            per_layer_ms = per_stage_ms / self._num_layers_per_pipeline_stage
+            self._cache[batch.id] = per_layer_ms
+        return self._cache[batch.id]
+
+    # Map all model time to attention decode execution time
+    def _get_attention_decode_execution_time(self, batch: Batch) -> float:
+        return self._predict_per_layer_time_ms(batch)
+
+    def _get_other_time(self, batch: Batch) -> float:
+        return 0.0
+
+    def _get_attention_layer_pre_proj_execution_time(self, batch: Batch) -> float:
+        return 0.0
+
+    def _get_attention_layer_post_proj_execution_time(self, batch: Batch) -> float:
+        return 0.0
+
+    def _get_attention_rope_execution_time(self, batch: Batch) -> float:
+        return 0.0
+
+    def _get_attention_kv_cache_save_execution_time(self, batch: Batch) -> float:
+        return 0.0
+
+    def _get_attention_prefill_execution_time(self, batch: Batch) -> float:
+        return 0.0
+
+    def _get_mlp_layer_up_proj_execution_time(self, batch: Batch) -> float:
+        return 0.0
+
+    def _get_mlp_layer_down_proj_execution_time(self, batch: Batch) -> float:
+        return 0.0
+
+    def _get_mlp_layer_act_execution_time(self, batch: Batch) -> float:
+        return 0.0
+
+    def _get_tensor_parallel_communication_time(self, batch: Batch) -> float:
+        return 0.0
+
+    def _get_pipeline_parallel_communication_time(self, batch: Batch) -> float:
+        return 0.0
+
+    def _get_schedule_time(self, batch: Batch) -> float:
+        return 0.0
+
+    def _get_sampler_e2e_time(self, batch: Batch) -> float:
+        return 0.0
+
+    def _get_prepare_inputs_e2e_time(self, batch: Batch) -> float:
+        return 0.0
+
+    def _get_process_model_outputs_time(self, batch: Batch) -> float:
+        return 0.0
+
+    def _get_ray_comm_time(self, batch: Batch) -> float:
+        return 0.0
+
+    def _get_mlp_norm_layer_act_execution_time(self, batch: Batch) -> float:
+        return 0.0
+
+    def _get_attn_norm_layer_act_execution_time(self, batch: Batch) -> float:
+        return 0.0
+
+    def _get_add_layer_act_execution_time(self, batch: Batch) -> float:
+        return 0.0

--- a/vidur/vidur/types/execution_time_predictor_type.py
+++ b/vidur/vidur/types/execution_time_predictor_type.py
@@ -5,3 +5,4 @@ class ExecutionTimePredictorType(BaseIntEnum):
     DUMMY = 1
     RANDOM_FORREST = 2
     LINEAR_REGRESSION = 3
+    LLM_VIEWER = 4


### PR DESCRIPTION
## Summary
- add a new execution time predictor that uses LLM‑Viewer
- register `LLM_VIEWER` predictor type
- add config option for enabling the new predictor

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6850275f763083228f3119f95dcdeffb